### PR TITLE
Try upstream directly

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,9 +50,10 @@ RUN \
 ENV PATH=/opt/anaconda3/bin:$PATH
 WORKDIR /tmp
 RUN \
-    npm install -g configurable-http-proxy              &&  \
-    git clone https://github.com/NERSC/jupyterhub.git   &&  \
-    cd jupyterhub                                       &&  \
-    /opt/anaconda3/bin/python setup.py js               &&  \
-    /opt/anaconda3/bin/pip install .                    &&  \
+    npm install -g configurable-http-proxy                  &&  \
+    git clone https://github.com/jupyterhub/jupyterhub.git  &&  \
+    cd jupyterhub                                           &&  \
+    git checkout tags/0.8.0rc1                              &&  \
+    /opt/anaconda3/bin/python setup.py js                   &&  \
+    /opt/anaconda3/bin/pip install .                        &&  \
     rm -rf ~/.cache ~/.npm

--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     mkdir /etc/grid-security/certificates/ && \
     cp /tmp/certs/* /etc/grid-security/certificates/ && \
     pip install git+https://github.com/NERSC/gsiauthenticator.git && \
-    pip install git+https://github.com/NERSC/sshspawner.git@v0.8updates
+    pip install git+https://github.com/NERSC/sshspawner.git
 
 WORKDIR /srv/
 EXPOSE 8000


### PR DESCRIPTION
So I think we can just forget our fork of jupyterhub now too.  Customizations we need for NEWT were the only thing added besides the NERSC custom user directory thing, and the latter is handled now totally by configuration.  For the former I think we may be able to just do it via the login template configuration (extra html).  We could see if we can add whatever tags we need back to the upstream when we get back to that.