### PR TITLE
Enable cull idle servers

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -57,4 +57,5 @@ RUN \
     /opt/anaconda3/bin/python setup.py js                           &&  \
     /opt/anaconda3/bin/pip install .                                &&  \
     cp examples/cull-idle/cull_idle_servers.py /opt/anaconda3/bin/. &&  \
+    chmod u+x /opt/anaconda3/bin/cull_idle_servers.py               &&  \
     rm -rf ~/.cache ~/.npm

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,10 +50,11 @@ RUN \
 ENV PATH=/opt/anaconda3/bin:$PATH
 WORKDIR /tmp
 RUN \
-    npm install -g configurable-http-proxy                  &&  \
-    git clone https://github.com/jupyterhub/jupyterhub.git  &&  \
-    cd jupyterhub                                           &&  \
-    git checkout tags/0.8.0                                 &&  \
-    /opt/anaconda3/bin/python setup.py js                   &&  \
-    /opt/anaconda3/bin/pip install .                        &&  \
+    npm install -g configurable-http-proxy                          &&  \
+    git clone https://github.com/jupyterhub/jupyterhub.git          &&  \
+    cd jupyterhub                                                   &&  \
+    git checkout tags/0.8.0                                         &&  \
+    /opt/anaconda3/bin/python setup.py js                           &&  \
+    /opt/anaconda3/bin/pip install .                                &&  \
+    cp examples/cull-idle/cull_idle_servers.py /opt/anaconda3/bin/. &&  \
     rm -rf ~/.cache ~/.npm

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -278,7 +278,13 @@ c.JupyterHub.hub_port = 8082
 #              'environment':
 #          }
 #      ]
-#c.JupyterHub.services = []
+c.JupyterHub.services = [
+    {
+        'name': 'cull-idle',
+        'admin': True,
+        'command': 'cull_idle_servers.py --timeout=43200'.split(),
+    }
+]
 
 ## The class to use for spawning single-user servers.
 #  

--- a/jupyter/jupyterhub/jupyterhub_config.py
+++ b/jupyter/jupyterhub/jupyterhub_config.py
@@ -271,7 +271,13 @@ c.JupyterHub.proxy_api_ip = '127.0.0.1'
 #              'environment':
 #          }
 #      ]
-#c.JupyterHub.services = []
+c.JupyterHub.services = [
+    {
+        'name': 'cull-idle',
+        'admin': True,
+        'command': 'cull_idle_servers.py --timeout=300'.split(),
+    }
+]
 
 ## The class to use for spawning single-user servers.
 #  

--- a/jupyter/jupyterhub/jupyterhub_config.py
+++ b/jupyter/jupyterhub/jupyterhub_config.py
@@ -275,7 +275,7 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': 'cull_idle_servers.py --timeout=300'.split(),
+        'command': 'cull_idle_servers.py --timeout=43200'.split(),
     }
 ]
 


### PR DESCRIPTION
This sets up `cull_idle_servers.py` as a service with a 12 hour timeout.  The script is put into `PATH` in the base image and then the individual images have the setup in the services block of their configuration files.