### PR TITLE
Use postgresql backend

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -39,6 +39,7 @@ RUN \
         mako            \
         markupsafe      \
         nodejs          \
+        psycopg2        \
         pyopenssl       \
         python-dateutil \
         sqlalchemy      \

--- a/jupyter-dev-db/Dockerfile
+++ b/jupyter-dev-db/Dockerfile
@@ -1,7 +1,5 @@
 FROM postgres:10.0
 MAINTAINER Rollin Thomas <rcthomas@lbl.com>
 
-RUN \
-    mkdir -p /docker-entrypoint-initdb.d
-
-COPY initdb.sh /docker-entrypoint-initdb.d/init.sh
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY initdb.sh /docker-entrypoint-initdb.d/initdb.sh

--- a/jupyter-dev-db/Dockerfile
+++ b/jupyter-dev-db/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres:10.0
+MAINTAINER Rollin Thomas <rcthomas@lbl.com>
+
+RUN \
+    mkdir -p /docker-entrypoint-initdb.d
+
+COPY initdb.sh /docker-entrypoint-initdb.d/init.sh

--- a/jupyter-dev-db/initdb.sh
+++ b/jupyter-dev-db/initdb.sh
@@ -3,7 +3,7 @@
 echo "";
 echo "Running initdb.sh.";
 if [ -z "$JPY_PSQL_PASSWORD" ]; then
-    echo "Need to set JPY_PSQL_PASSWORD in Dockerfile or via command line.";
+    echo "Need to set JPY_PSQL_PASSWORD in Dockerfile or via environment.";
     exit 1;
 fi
 echo "";

--- a/jupyter-dev-db/initdb.sh
+++ b/jupyter-dev-db/initdb.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "";
+echo "Running initdb.sh.";
+if [ -z "$JPY_PSQL_PASSWORD" ]; then
+    echo "Need to set JPY_PSQL_PASSWORD in Dockerfile or via command line.";
+    exit 1;
+fi
+echo "";
+
+# Start a postgres daemon, ignoring log output.
+# gosu postgres pg_ctl start -w -l /dev/null
+
+# Create a Jupyterhub user and database.
+psql --user postgres -c "CREATE DATABASE jupyterhub;"
+psql --user postgres -c "CREATE USER jupyterhub WITH ENCRYPTED PASSWORD '$JPY_PSQL_PASSWORD';"
+psql --user postgres -c "GRANT ALL PRIVILEGES ON DATABASE jupyterhub TO jupyterhub;"
+
+# Alter pg_hba.conf to actually require passwords.  The default image exposes
+# allows any user to connect without requiring a password, which is a liability
+# if this is run forwarding ports from the host machine.
+sed -ri -e 's/(host all all all )(trust)/\1md5/' "$PGDATA"/pg_hba.conf
+
+# Stop the daemon.  The root Dockerfile will restart the server for us.
+# gosu postgres pg_ctl stop -w

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -156,6 +156,12 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 ## url for the database. e.g. `sqlite:///jupyterhub.sqlite`
 #c.JupyterHub.db_url = 'sqlite:///jupyterhub.sqlite'
+pg_pass = os.getenv('POSTGRES_ENV_JPY_PSQL_PASSWORD')
+pg_host = os.getenv('POSTGRES_PORT_5432_TCP_ADDR')
+c.JupyterHub.db_url = 'postgresql://jupyterhub:{}@{}:5432/jupyterhub'.format(
+        pg_pass,
+        pg_host,
+)
 
 ## log all database transactions. This has A LOT of output
 #c.JupyterHub.debug_db = False


### PR DESCRIPTION
These changes allow us to start using a PostgreSQL container for the JupyterHub database.  We might want the data files to end up on a directory in spin though.  I would save that for a future PR and just want to ask for people to take a look here.