### PR TITLE
Clean up dockerfile

### DIFF
--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -19,7 +19,10 @@ RUN \
     pip install git+https://github.com/NERSC/gsiauthenticator.git && \
     pip install git+https://github.com/NERSC/sshspawner.git
 
-WORKDIR /srv/
 
-ADD jupyterhub_config.py /srv/jupyterhub_config.py
+ADD jupyterhub_config.py docker-entrypoint.sh /srv/
+
+WORKDIR /srv
+RUN chmod +x docker-entrypoint.sh
 CMD ["jupyterhub", "--debug"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -20,9 +20,6 @@ RUN \
     pip install git+https://github.com/NERSC/sshspawner.git
 
 WORKDIR /srv/
-EXPOSE 8000
-
-LABEL org.jupyter.service="jupyterhub"
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 CMD ["jupyterhub", "--debug"]

--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.spin.nersc.gov/das/jupyterhub-base:latest
 MAINTAINER Rollin Thomas <rcthomas@lbl.com>
 
-# Add gsissh
+# Install gsissh
 
 RUN \
   echo "deb http://downloads.globus.org/toolkit/gt6/stable/deb/ jessie contrib" >> /etc/apt/sources.list && \
@@ -9,12 +9,13 @@ RUN \
   apt-get update && \
   apt-get --yes install gsi-openssh-clients
 
-# Add edisongrid cert
+# Add certs
 
-ADD ./certs /tmp/certs/
+ADD certs /etc/grid-security/certificates
+
+# JupyterHub GSI Authenticator and SSH Spawner from NERSC
+  
 RUN \
-    mkdir /etc/grid-security/certificates/ && \
-    cp /tmp/certs/* /etc/grid-security/certificates/ && \
     pip install git+https://github.com/NERSC/gsiauthenticator.git && \
     pip install git+https://github.com/NERSC/sshspawner.git
 

--- a/jupyter-dev/docker-entrypoint.sh
+++ b/jupyter-dev/docker-entrypoint.sh
@@ -15,10 +15,8 @@ file_env() {
     fi
     local val="$def"
     if [ "${!var:-}" ]; then
-        echo 1
         val="${!var}"
     elif [ "${!fileVar:-}" ]; then
-        echo 2
         val="$(< "${!fileVar}")"
     fi
     export "$var"="$val"

--- a/jupyter-dev/docker-entrypoint.sh
+++ b/jupyter-dev/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# file_env VAR [DEFAULT]
+# ----------------------
+# Treat the value of VAR_FILE as the path to a secrets file and initialize VAR
+# with the contents of that file.  From postgres docker-entrypoint.sh.
+
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        echo 1
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        echo 2
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+file_env 'POSTGRES_PASSWORD'
+
+exec "$@"

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -156,11 +156,8 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 ## url for the database. e.g. `sqlite:///jupyterhub.sqlite`
 #c.JupyterHub.db_url = 'sqlite:///jupyterhub.sqlite'
-pg_pass = os.getenv('POSTGRES_ENV_JPY_PSQL_PASSWORD')
-pg_host = os.getenv('POSTGRES_PORT_5432_TCP_ADDR')
-c.JupyterHub.db_url = 'postgresql://jupyterhub:{}@{}:5432/jupyterhub'.format(
-        pg_pass,
-        pg_host,
+c.JupyterHub.db_url = 'postgresql://jupyterhub:{}@db:5432/jupyterhub'.format(
+        os.getenv('POSTGRES_PASSWORD')
 )
 
 ## log all database transactions. This has A LOT of output

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -286,7 +286,7 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': 'cull_idle_servers.py --timeout=43200'.split(),
+        'command': 'cull_idle_servers.py --timeout=86400'.split(),
     }
 ]
 


### PR DESCRIPTION
This PR cleans up our Dockerfile a little bit and introduces an entrypoint script to use in tandem with the command.  The entrypoint script mainly obtains the database credentials from a secret and then runs whatever command it is passed (`jupyterhub --debug` by default).

In terms of clean-up, I think the part of the Dockerfile where we copied in certs was a little more complicated than it had to be, and I've combined the add's to /srv which include the entrypoint and config.  The config has also been adjusted to follow the entrypoint script conventions.  I have a few specific questions:

@scanon: Do we need both sets of files in the certs directory?

@scanon and @shreddd both --- I am gone until Thursday but when I get back it would be good to go over the Dockerfile in a room together and make sure we like all our settings and maybe document them a little more from our collective memory.

Once that is done I think we would be ready to have this reviewed by ISG.  At that point we should be ready to cut -test over to -dev, I am told.

Tested.