### PR TITLE
Hotfix torgo

### DIFF
--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -19,6 +19,11 @@ RUN \
     pip install git+https://github.com/NERSC/gsiauthenticator.git && \
     pip install git+https://github.com/NERSC/sshspawner.git
 
+# Volume for user cert/key files
+
+VOLUME /certs
+
+# Config and entrypoint script
 
 ADD jupyterhub_config.py docker-entrypoint.sh /srv/
 

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -779,6 +779,7 @@ c.Authenticator.admin_users = set(os.environ.get("ADMINS", "").split(","))
 
 c.GSIAuthenticator.proxy_lifetime = 999999
 c.GSIAuthenticator.server = 'nerscca1.nersc.gov'
+c.GSIAuthenticator.cert_path_prefix = '/certs/x509_'
 
 #------------------------------------------------------------------------------
 # SSHSpawner(Spawner) configuration

--- a/jupyter-dev/jupyterhub_config.py
+++ b/jupyter-dev/jupyterhub_config.py
@@ -552,7 +552,7 @@ c.Spawner.notebook_dir = '/'
 #  JupyterHub modifies its own state accordingly and removes appropriate routes
 #  from the configurable proxy.
 #c.Spawner.poll_interval = 30
-c.Spawner.poll_interval = 300
+c.Spawner.poll_interval = 1800
 
 ## The port for single-user servers to listen on.
 #  


### PR DESCRIPTION
This PR addresses a few of the issues I mentioned earlier today.  I've upped the poll interval to 30 minutes (1800s), changed the cert prefix and added it as a volume.

When setting this up in Spin I will add the Rancher NFS volumne for `/certs` and we should be good to go.  The only fall-out is that we will have no certs to begin with and duplicate servers will happen, but this should not happen again on a future reboot.  Going to give you guys a little while to look this over, I may wait until the morning to do the upgrade.