### PR TITLE
Trivial "change"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Rollin Thomas <rcthomas@lbl.gov>
+LABEL maintainer="Rollin Thomas <rcthomas@lbl.gov>"
 
 # Base Ubuntu packages
 

--- a/jupyter-dev/Dockerfile
+++ b/jupyter-dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.spin.nersc.gov/das/jupyterhub-base:latest
-MAINTAINER Rollin Thomas <rcthomas@lbl.com>
+LABEL maintainer="Rollin Thomas <rcthomas@lbl.com>"
 
 # Install gsissh
 

--- a/jupyter-localhost/Dockerfile
+++ b/jupyter-localhost/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.spin.nersc.gov/das/jupyterhub-base:latest
-MAINTAINER Rollin Thomas <rcthomas@lbl.com>
+LABEL maintainer="Rollin Thomas <rcthomas@lbl.com>"
 
 # Python 3 Anaconda and additional packages
 

--- a/jupyter-off/Dockerfile
+++ b/jupyter-off/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.13.7-alpine
-MAINTAINER Rollin Thomas <rcthomas@lbl.com>
+LABEL maintainer="Rollin Thomas <rcthomas@lbl.com>"
 COPY html /usr/share/nginx/html
 COPY nginx.conf /etc/nginx

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.spin.nersc.gov/das/jupyterhub-base:latest
-MAINTAINER Rollin Thomas <rcthomas@lbl.com>
+LABEL maintainer="Rollin Thomas <rcthomas@lbl.com>"
 
 # Additional Ubuntu packages
 


### PR DESCRIPTION
Changed `MAINTAINER ...` instructions to `LABEL maintainer="..."`, since [the Docker documentation](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) says that the former is now deprecated and the latter is to be preferred (because the latter makes the maintainer visible when running `docker inspect`).