### PR TITLE
Use default_server_name feature name of JupyterHub 

### DIFF
--- a/jupyter-nersc/web-jupyterhub/jupyterhub_config.py
+++ b/jupyter-nersc/web-jupyterhub/jupyterhub_config.py
@@ -1199,3 +1199,5 @@ c.Spawner.auth_state_hook = auth_state_hook
 ### Prometheus
 
 c.JupyterHub.authenticate_prometheus = False
+
+c.JupyterHub.default_server_name = 'cori-shared-node-cpu'


### PR DESCRIPTION
Use default_server_name feature name of JupyterHub to better utilize user-redirect, plus no longer need to have two branches of clonenotebooks.